### PR TITLE
Fix legacy scale control timeout reset

### DIFF
--- a/feature/player/src/main/java/one/only/player/feature/player/MediaPlayerScreen.kt
+++ b/feature/player/src/main/java/one/only/player/feature/player/MediaPlayerScreen.kt
@@ -1217,6 +1217,7 @@ internal fun MediaPlayerScreen(
                                             if (isCustomizingControls) {
                                                 toggleControlVisibility(PlayerControl.SCALE)
                                             } else {
+                                                controlsVisibilityState.showControls()
                                                 videoZoomAndContentScaleState.switchToNextVideoContentScale()
                                             }
                                         },
@@ -1473,6 +1474,7 @@ internal fun MediaPlayerScreen(
                                             if (isCustomizingControls) {
                                                 toggleControlVisibility(PlayerControl.SCALE)
                                             } else {
+                                                controlsVisibilityState.showControls()
                                                 videoZoomAndContentScaleState.switchToNextVideoContentScale()
                                             }
                                         },


### PR DESCRIPTION
## What changed

- Reset the controller auto-hide timeout when the legacy layout's video scale button is clicked.
- Apply the reset for both top and bottom customizable control zones.

## Why

The legacy video scale callbacks changed the content scale without calling `showControls()`. As a result, the original auto-hide job kept running and hid the controls even while the user repeatedly interacted with the scale button.

## Impact

Repeated video scale clicks now keep the legacy controller visible until the configured timeout has elapsed since the most recent click.

Closes #180.

## Validation

- `./gradlew ktlintFormat ktlintCheck` — passed
- `./gradlew test assembleDebug --warning-mode=fail` — not run to completion because the local environment has no Android SDK configured
