### PR TITLE
fix: prevent the default media layout from flashing at cold start

### DIFF
--- a/core/data/src/main/java/one/only/player/core/data/repository/LocalPreferencesRepository.kt
+++ b/core/data/src/main/java/one/only/player/core/data/repository/LocalPreferencesRepository.kt
@@ -27,7 +27,7 @@ class LocalPreferencesRepository @Inject constructor(
             .stateIn(
                 scope = applicationScope,
                 started = SharingStarted.Eagerly,
-                initialValue = ApplicationPreferences(),
+                initialValue = sanitizeApplicationPreferences(appPreferencesDataSource.bootstrapPreferences),
             )
 
     override val playerPreferences: StateFlow<PlayerPreferences> =

--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -41,4 +41,6 @@ dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
     ksp(libs.kotlin.metadata.jvm)
+
+    testImplementation(libs.junit4)
 }

--- a/core/datastore/src/main/java/one/only/player/core/datastore/datasource/AppPreferencesDataSource.kt
+++ b/core/datastore/src/main/java/one/only/player/core/datastore/datasource/AppPreferencesDataSource.kt
@@ -1,11 +1,17 @@
 package one.only.player.core.datastore.datasource
 
+import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.dataStoreFile
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import one.only.player.core.common.Logger
+import one.only.player.core.datastore.di.APP_PREFERENCES_DATASTORE_FILE
+import one.only.player.core.datastore.serializer.ApplicationPreferencesSerializer
 import one.only.player.core.model.ApplicationPreferences
 
 class AppPreferencesDataSource @Inject constructor(
+    @ApplicationContext context: Context,
     private val appPreferences: DataStore<ApplicationPreferences>,
 ) : PreferencesDataSource<ApplicationPreferences> {
 
@@ -14,6 +20,9 @@ class AppPreferencesDataSource @Inject constructor(
     }
 
     override val preferences = appPreferences.data
+    val bootstrapPreferences = ApplicationPreferencesSerializer.readFromFile(
+        context.dataStoreFile(APP_PREFERENCES_DATASTORE_FILE),
+    )
 
     override suspend fun update(
         transform: suspend (ApplicationPreferences) -> ApplicationPreferences,

--- a/core/datastore/src/main/java/one/only/player/core/datastore/di/DataStoreModule.kt
+++ b/core/datastore/src/main/java/one/only/player/core/datastore/di/DataStoreModule.kt
@@ -23,7 +23,7 @@ import one.only.player.core.model.ApplicationPreferences
 import one.only.player.core.model.PlayerPreferences
 import one.only.player.core.model.SearchHistory
 
-private const val APP_PREFERENCES_DATASTORE_FILE = "app_preferences.json"
+internal const val APP_PREFERENCES_DATASTORE_FILE = "app_preferences.json"
 private const val PLAYER_PREFERENCES_DATASTORE_FILE = "player_preferences.json"
 private const val SEARCH_HISTORY_DATASTORE_FILE = "search_history.json"
 

--- a/core/datastore/src/main/java/one/only/player/core/datastore/serializer/ApplicationPreferencesSerializer.kt
+++ b/core/datastore/src/main/java/one/only/player/core/datastore/serializer/ApplicationPreferencesSerializer.kt
@@ -2,15 +2,18 @@ package one.only.player.core.datastore.serializer
 
 import androidx.datastore.core.CorruptionException
 import androidx.datastore.core.Serializer
+import java.io.File
 import java.io.InputStream
 import java.io.OutputStream
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
+import one.only.player.core.common.Logger
 import one.only.player.core.model.ApplicationPreferences
 
 object ApplicationPreferencesSerializer : Serializer<ApplicationPreferences> {
 
+    private const val TAG = "ApplicationPreferencesSerializer"
     private val jsonFormat = Json { ignoreUnknownKeys = true }
     private val legacyKeys = setOf(
         "ignoreNoMediaFiles",
@@ -28,9 +31,23 @@ object ApplicationPreferencesSerializer : Serializer<ApplicationPreferences> {
     override val defaultValue: ApplicationPreferences
         get() = ApplicationPreferences()
 
-    override suspend fun readFrom(input: InputStream): ApplicationPreferences {
-        val serializedPreferences = input.readBytes().decodeToString()
+    override suspend fun readFrom(input: InputStream): ApplicationPreferences =
+        decode(input.readBytes().decodeToString())
 
+    fun readFromFile(file: File): ApplicationPreferences {
+        if (!file.exists()) return defaultValue
+
+        return try {
+            file.inputStream().use { input ->
+                decode(input.readBytes().decodeToString())
+            }
+        } catch (exception: Exception) {
+            Logger.error(TAG, "Failed to bootstrap app preferences: $exception")
+            defaultValue
+        }
+    }
+
+    private fun decode(serializedPreferences: String): ApplicationPreferences {
         if (serializedPreferences.containsLegacyApplicationPreferences()) {
             throw CorruptionException(
                 message = "Cannot read datastore",
@@ -38,8 +55,8 @@ object ApplicationPreferencesSerializer : Serializer<ApplicationPreferences> {
             )
         }
 
-        try {
-            return jsonFormat.decodeFromString(
+        return try {
+            jsonFormat.decodeFromString(
                 deserializer = ApplicationPreferences.serializer(),
                 string = serializedPreferences,
             )

--- a/core/datastore/src/test/java/one/only/player/core/datastore/serializer/ApplicationPreferencesSerializerTest.kt
+++ b/core/datastore/src/test/java/one/only/player/core/datastore/serializer/ApplicationPreferencesSerializerTest.kt
@@ -1,0 +1,93 @@
+package one.only.player.core.datastore.serializer
+
+import java.io.File
+import one.only.player.core.model.ApplicationPreferences
+import one.only.player.core.model.MediaLayoutMode
+import one.only.player.core.model.MediaViewMode
+import one.only.player.core.model.Sort
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class ApplicationPreferencesSerializerTest {
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun readFromFilePreservesSavedMediaSelections() {
+        val preferencesFile = temporaryFolder.newFile().apply {
+            writeText(
+                """
+                {
+                    "mediaLayoutMode": "GRID",
+                    "mediaViewMode": "VIDEOS",
+                    "mediaLayoutScale": 1.35,
+                    "sortBy": "DATE",
+                    "sortOrder": "DESCENDING"
+                }
+                """.trimIndent(),
+            )
+        }
+
+        val preferences = ApplicationPreferencesSerializer.readFromFile(preferencesFile)
+
+        assertEquals(MediaLayoutMode.GRID, preferences.mediaLayoutMode)
+        assertEquals(MediaViewMode.VIDEOS, preferences.mediaViewMode)
+        assertEquals(1.35f, preferences.mediaLayoutScale)
+        assertEquals(Sort.By.DATE, preferences.sortBy)
+        assertEquals(Sort.Order.DESCENDING, preferences.sortOrder)
+    }
+
+    @Test
+    fun readFromFileIgnoresUnknownFields() {
+        val preferencesFile = temporaryFolder.newFile().apply {
+            writeText(
+                """
+                {
+                    "mediaLayoutMode": "GRID",
+                    "mediaViewMode": "FOLDER_TREE",
+                    "futurePreference": true
+                }
+                """.trimIndent(),
+            )
+        }
+
+        val preferences = ApplicationPreferencesSerializer.readFromFile(preferencesFile)
+
+        assertEquals(MediaLayoutMode.GRID, preferences.mediaLayoutMode)
+        assertEquals(MediaViewMode.FOLDER_TREE, preferences.mediaViewMode)
+    }
+
+    @Test
+    fun readFromFileReturnsDefaultForMissingFile() {
+        val missingFile = File(temporaryFolder.root, "missing.json")
+
+        assertEquals(ApplicationPreferences(), ApplicationPreferencesSerializer.readFromFile(missingFile))
+    }
+
+    @Test
+    fun readFromFileReturnsDefaultForUnreadableFile() {
+        val unreadableFile = temporaryFolder.newFolder("preferences.json")
+
+        assertEquals(ApplicationPreferences(), ApplicationPreferencesSerializer.readFromFile(unreadableFile))
+    }
+
+    @Test
+    fun readFromFileReturnsDefaultForUnreadablePayloads() {
+        val payloads = listOf(
+            "",
+            "not-json",
+            """{"ignoreNoMediaFiles":true,"mediaLayoutMode":"GRID"}""",
+        )
+
+        payloads.forEachIndexed { index, payload ->
+            val preferencesFile = temporaryFolder.newFile("invalid-$index.json").apply {
+                writeText(payload)
+            }
+
+            assertEquals(ApplicationPreferences(), ApplicationPreferencesSerializer.readFromFile(preferencesFile))
+        }
+    }
+}


### PR DESCRIPTION
Expose a serializer-backed, non-suspending decode path that can parse the persisted application-preferences payload with the same unknown-key and corruption behavior used by DataStore, returning defaults when the file is absent or unreadable. Have `AppPreferencesDataSource` read that small persisted payload once during construction and expose it as its bootstrap value, sharing the application-preferences filename declared by `DataStoreModule` so the bootstrap and DataStore cannot drift to different files. Initialize `LocalPreferencesRepository.applicationPreferences` from the data source's bootstrap value instead of `ApplicationPreferences()`, while continuing to collect the DataStore flow eagerly so disk migrations, sanitization, and later preference changes remain authoritative. Issue #184 reports several performance symptoms, including a cold start that briefly renders the default media layout before switching to the user's saved layout. The local preference pipeline provides a concrete explanation for that flash: `LocalPreferencesRepository.applicationPreferences` is eagerly converted to a `StateFlow` with `ApplicationPreferences()` as its initial value, so `MainViewModel` and `MediaPickerViewModel` can render the default `LIST` layout before DataStore reads disk. The repository already has an app-startup precedent for synchronously reading the small preferences file to bootstrap theme-related UI, while the authoritative DataStore flow remains responsible for subsequent updates. This plan covers only the cold-start layout flash because the reporter says reinstalling largely resolved the player lag and the sort/refresh symptoms do not yet have an equally concrete diagnosis.

Testing: Decode a valid persisted payload with non-default `mediaLayoutMode`, `mediaViewMode`, layout scale, and sort settings, and verify the bootstrap value preserves those selections before the asynchronous DataStore flow emits; Decode a payload containing unknown fields and verify supported saved layout fields are retained, matching the serializer's forward-compatible `ignoreUnknownKeys` behavior.

Fixes #184
