### PR TITLE
fix: stabilize slight seek gestures

### DIFF
--- a/feature/player/src/main/java/one/only/player/feature/player/extensions/PointerInputScope.kt
+++ b/feature/player/src/main/java/one/only/player/feature/player/extensions/PointerInputScope.kt
@@ -140,7 +140,8 @@ suspend fun PointerInputScope.detectCustomHorizontalDragGestures(
             overSlop = over
         }
         if (drag != null && currentEvent.changes.count { it.pressed } == 1) {
-            onDragStart.invoke(drag.position)
+            // Preserve the initial origin so absolute drag consumers include the touch slop distance.
+            onDragStart.invoke(down.position)
             onHorizontalDrag(drag, overSlop)
             if (
                 horizontalDrag(drag.id) {


### PR DESCRIPTION
## Summary

- anchor horizontal seek gestures to the initial pointer-down position
- preserve the touch-slop distance so small post-threshold movements do not oscillate progress around the original position

## Testing

- git diff --check
- Gradle checks not run: the existing Windows cache only has Gradle 9.4.1, while the project requires Gradle 9.6.0

Closes #186