### PR TITLE
fix: stabilize seek preview and deduplicate local media

### DIFF
--- a/core/media/src/main/java/one/only/player/core/media/sync/LocalMediaSynchronizer.kt
+++ b/core/media/src/main/java/one/only/player/core/media/sync/LocalMediaSynchronizer.kt
@@ -13,6 +13,8 @@ import androidx.core.net.toUri
 import coil3.ImageLoader
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
+import java.nio.file.Files
+import java.util.Locale
 import javax.inject.Inject
 import kotlin.math.absoluteValue
 import kotlinx.coroutines.CoroutineDispatcher
@@ -71,6 +73,23 @@ private fun String.isInsideScanFolders(scanFolderPaths: List<String>): Boolean {
     return scanFolderPaths.any { scanFolder ->
         this == scanFolder || startsWith("$scanFolder/")
     }
+}
+
+private fun List<MediaVideo>.distinctByEquivalentPath(): List<MediaVideo> {
+    val pathsByCaseFoldedPath = mutableMapOf<String, MutableList<String>>()
+    return filter { mediaVideo ->
+        val path = mediaVideo.data.canonicalPathOrSelf()
+        val equivalentPaths = pathsByCaseFoldedPath.getOrPut(path.lowercase(Locale.ROOT)) { mutableListOf() }
+        if (equivalentPaths.any { existingPath -> existingPath.isSameFileAs(path) }) return@filter false
+
+        equivalentPaths += path
+        true
+    }
+}
+
+private fun String.isSameFileAs(other: String): Boolean {
+    if (this == other) return true
+    return runCatching { Files.isSameFile(File(this).toPath(), File(other).toPath()) }.getOrDefault(false)
 }
 
 private data class AutomaticMediaSyncSettings(
@@ -418,7 +437,7 @@ class LocalMediaSynchronizer @Inject constructor(
             .map { it.toBasicMediaVideo() }
             .toList()
         val media = (mediaStoreVideos + manualVideos)
-            .distinctBy { mediaVideo -> mediaVideo.data.canonicalPathOrSelf() }
+            .distinctByEquivalentPath()
             .filter { mediaVideo -> mediaVideo.data.canonicalPathOrSelf().isInsideScanFolders(scanFolderPaths) }
 
         val existingMedia = mediumDao.getAll().first()
@@ -590,7 +609,7 @@ class LocalMediaSynchronizer @Inject constructor(
         )
         if (!shouldIgnoreNoMediaFiles || !hasAllFilesAccess) {
             return@withContext combinedVisibleMedia
-                .distinctBy { mediaVideo -> mediaVideo.data.canonicalPathOrSelf() }
+                .distinctByEquivalentPath()
                 .sortedBy(MediaVideo::data)
         }
 
@@ -599,13 +618,13 @@ class LocalMediaSynchronizer @Inject constructor(
         }
         if (noMediaVideos.isEmpty()) {
             return@withContext combinedVisibleMedia
-                .distinctBy(MediaVideo::data)
+                .distinctByEquivalentPath()
                 .sortedBy(MediaVideo::data)
         }
 
         Logger.info(TAG, "Found ${noMediaVideos.size} videos inside .nomedia directories")
         return@withContext (combinedVisibleMedia + noMediaVideos)
-            .distinctBy { mediaVideo -> mediaVideo.data.canonicalPathOrSelf() }
+            .distinctByEquivalentPath()
             .sortedBy(MediaVideo::data)
     }
 

--- a/feature/player/src/main/java/one/only/player/feature/player/MediaPlayerScreen.kt
+++ b/feature/player/src/main/java/one/only/player/feature/player/MediaPlayerScreen.kt
@@ -243,6 +243,7 @@ internal fun MediaPlayerScreen(
         player = player,
         sensitivity = playerPreferences.seekSensitivity,
         isSeekGestureEnabled = playerPreferences.shouldUseSeekControls,
+        onSeekCommitted = mediaPresentationState::updatePositionAfterSeek,
     )
     val pictureInPictureState = rememberPictureInPictureState(
         player = player,
@@ -1008,6 +1009,7 @@ internal fun MediaPlayerScreen(
                                 ControlsBottomModernView(
                                     mediaPresentationState = mediaPresentationState,
                                     pendingSeekPosition = seekGestureState.pendingSeekPosition,
+                                    shouldAnimateSeekPreview = seekGestureState.shouldAnimatePreview,
                                     isPlaying = mediaPresentationState.isPlaying,
                                     hasPrevious = player.hasPreviousMediaItem(),
                                     hasNext = player.hasNextMediaItem(),

--- a/feature/player/src/main/java/one/only/player/feature/player/state/MediaPresentationState.kt
+++ b/feature/player/src/main/java/one/only/player/feature/player/state/MediaPresentationState.kt
@@ -140,6 +140,10 @@ class MediaPresentationState(
         }
     }
 
+    fun updatePositionAfterSeek(positionMs: Long) {
+        position = positionMs.coerceAtLeast(0L)
+    }
+
     private fun updatePosition() {
         position = player.currentPosition.coerceAtLeast(0L)
     }

--- a/feature/player/src/main/java/one/only/player/feature/player/state/SeekGestureState.kt
+++ b/feature/player/src/main/java/one/only/player/feature/player/state/SeekGestureState.kt
@@ -6,8 +6,8 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.media3.common.C
 import androidx.media3.common.Player
@@ -25,12 +25,15 @@ fun rememberSeekGestureState(
     player: Player,
     sensitivity: Float = 0.5f,
     isSeekGestureEnabled: Boolean,
+    onSeekCommitted: (Long) -> Unit = {},
 ): SeekGestureState {
-    val seekGestureState = remember {
+    val currentOnSeekCommitted = rememberUpdatedState(onSeekCommitted)
+    val seekGestureState = remember(player, sensitivity, isSeekGestureEnabled) {
         SeekGestureState(
             player = player,
             sensitivity = sensitivity,
             isSeekGestureEnabled = isSeekGestureEnabled,
+            onSeekCommitted = { position -> currentOnSeekCommitted.value(position) },
         )
     }
     return seekGestureState
@@ -41,6 +44,7 @@ class SeekGestureState(
     private val player: Player,
     private val isSeekGestureEnabled: Boolean = true,
     private val sensitivity: Float = 0.5f,
+    private val onSeekCommitted: (Long) -> Unit = {},
 ) {
     var isSeeking: Boolean by mutableStateOf(false)
         private set
@@ -54,7 +58,10 @@ class SeekGestureState(
     var pendingSeekPosition: Long? by mutableStateOf(null)
         private set
 
-    private var seekStartX = 0f
+    var shouldAnimatePreview: Boolean by mutableStateOf(false)
+        private set
+
+    private val dragStabilizer = SeekDragStabilizer()
 
     fun onSeek(value: Long) {
         val duration = player.availableDurationMs()
@@ -63,6 +70,7 @@ class SeekGestureState(
 
         if (!isSeeking) {
             isSeeking = true
+            shouldAnimatePreview = false
             seekStartPosition = currentPosition
             pendingSeekPosition = currentPosition
             player.setIsScrubbingModeEnabled(true)
@@ -81,14 +89,15 @@ class SeekGestureState(
         reset()
     }
 
-    fun onDragStart(offset: Offset) {
+    fun onDragStart() {
         if (!isSeekGestureEnabled) return
         val duration = player.availableDurationMs()
         if (duration == C.TIME_UNSET || duration <= 0L) return
         val currentPosition = player.currentPosition.takeIf { it != C.TIME_UNSET } ?: 0L
 
         isSeeking = true
-        seekStartX = offset.x
+        shouldAnimatePreview = true
+        dragStabilizer.reset()
         seekStartPosition = currentPosition
         pendingSeekPosition = currentPosition
 
@@ -96,7 +105,11 @@ class SeekGestureState(
     }
 
     @OptIn(UnstableApi::class)
-    fun onDrag(change: PointerInputChange, dragAmount: Float) {
+    fun onDrag(
+        change: PointerInputChange,
+        dragAmount: Float,
+        hysteresisPx: Float,
+    ) {
         val seekStartPosition = seekStartPosition ?: return
         val duration = player.availableDurationMs()
         if (duration == C.TIME_UNSET) return
@@ -106,8 +119,11 @@ class SeekGestureState(
         if (currentPreviewPosition <= 0L && dragAmount < 0) return
         if (currentPreviewPosition >= duration && dragAmount > 0) return
 
-        val newPosition = (seekStartPosition + ((change.position.x - seekStartX) * (sensitivity * 100)).toInt())
+        val stabilizedDragAmount = dragStabilizer.add(dragAmount, hysteresisPx) ?: return
+        val newPosition = (seekStartPosition + (stabilizedDragAmount * (sensitivity * 100)).toLong())
             .coerceIn(0L, duration)
+        if (newPosition == currentPreviewPosition) return
+
         pendingSeekPosition = newPosition
         seekAmount = (newPosition - seekStartPosition).coerceIn(
             minimumValue = 0 - seekStartPosition,
@@ -122,10 +138,13 @@ class SeekGestureState(
 
     private fun commitPendingSeek() {
         val pendingSeekPosition = pendingSeekPosition ?: return
+        val seekAmount = seekAmount ?: return
+        if (seekAmount == 0L) return
         val currentPosition = player.currentPosition.takeIf { it != C.TIME_UNSET }
         if (currentPosition == null || currentPosition != pendingSeekPosition) {
             player.seekToRequestedPosition(pendingSeekPosition)
         }
+        onSeekCommitted(pendingSeekPosition)
     }
 
     private fun reset() {
@@ -134,8 +153,29 @@ class SeekGestureState(
         seekStartPosition = null
         seekAmount = null
         pendingSeekPosition = null
+        shouldAnimatePreview = false
 
-        seekStartX = 0f
+        dragStabilizer.reset()
+    }
+}
+
+internal class SeekDragStabilizer {
+    private var rawDragAmount = 0f
+    private var stabilizedDragAmount = 0f
+
+    fun add(dragAmount: Float, hysteresisPx: Float): Float? {
+        rawDragAmount += dragAmount
+        val safeHysteresis = hysteresisPx.coerceAtLeast(0f)
+        val difference = rawDragAmount - stabilizedDragAmount
+        if (abs(difference) <= safeHysteresis) return null
+
+        stabilizedDragAmount = rawDragAmount - kotlin.math.sign(difference) * safeHysteresis
+        return stabilizedDragAmount
+    }
+
+    fun reset() {
+        rawDragAmount = 0f
+        stabilizedDragAmount = 0f
     }
 }
 

--- a/feature/player/src/main/java/one/only/player/feature/player/ui/PlayerGestures.kt
+++ b/feature/player/src/main/java/one/only/player/feature/player/ui/PlayerGestures.kt
@@ -122,7 +122,7 @@ fun PlayerGestures(
                             onDragStart = {
                                 if (tapGestureState.isLongPressGestureCaptured) return@detectCustomHorizontalDragGestures
                                 val wasControlsVisible = controlsVisibilityState.isControlsVisible
-                                seekGestureState.onDragStart(it)
+                                seekGestureState.onDragStart()
                                 shouldRestoreControlsAutoHideAfterSeek = wasControlsVisible && seekGestureState.isSeeking
                                 if (shouldRestoreControlsAutoHideAfterSeek) {
                                     controlsVisibilityState.showControls(duration = Duration.INFINITE)
@@ -133,7 +133,11 @@ fun PlayerGestures(
                                     change.consume()
                                     return@detectCustomHorizontalDragGestures
                                 }
-                                seekGestureState.onDrag(change, dragAmount)
+                                seekGestureState.onDrag(
+                                    change = change,
+                                    dragAmount = dragAmount,
+                                    hysteresisPx = viewConfiguration.touchSlop * SEEK_PREVIEW_HYSTERESIS_FRACTION,
+                                )
                             },
                             onDragCancel = {
                                 try {
@@ -292,6 +296,7 @@ private const val CHAPTER_SWIPE_DIRECTION_RATIO = 1.5f
 private const val CHAPTER_SWIPE_MAX_SCALE_DELTA = 0.06f
 private const val CHAPTER_SWIPE_MAX_ROTATION_DEGREES = 8f
 private const val CHAPTER_SWIPE_MAX_ACTIVE_ZOOM = 1.02f
+private const val SEEK_PREVIEW_HYSTERESIS_FRACTION = 0.05f
 
 enum class ChapterSwipeDirection {
     PREVIOUS,

--- a/feature/player/src/main/java/one/only/player/feature/player/ui/controls/ControlsBottomModernView.kt
+++ b/feature/player/src/main/java/one/only/player/feature/player/ui/controls/ControlsBottomModernView.kt
@@ -1,5 +1,9 @@
 package one.only.player.feature.player.ui.controls
 
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -23,8 +27,11 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -57,6 +64,7 @@ internal fun ControlsBottomModernView(
     modifier: Modifier = Modifier,
     mediaPresentationState: MediaPresentationState,
     pendingSeekPosition: Long?,
+    shouldAnimateSeekPreview: Boolean,
     isPlaying: Boolean,
     hasPrevious: Boolean,
     hasNext: Boolean,
@@ -89,6 +97,7 @@ internal fun ControlsBottomModernView(
             ),
             position = displayedPosition.toFloat(),
             duration = mediaPresentationState.duration.toFloat(),
+            shouldAnimatePosition = shouldAnimateSeekPreview,
             onSeek = {
                 controlsVisibilityState?.showControls()
                 onSeek(it.toLong())
@@ -177,14 +186,38 @@ private fun ModernSeekbar(
     modifier: Modifier = Modifier,
     position: Float,
     duration: Float,
+    shouldAnimatePosition: Boolean,
     onSeek: (Float) -> Unit,
     onSeekFinished: () -> Unit,
 ) {
     val accentColor = MaterialTheme.colorScheme.primary
+    val targetPosition = position.coerceIn(0f, duration.coerceAtLeast(0f))
+    var continueAnimatingAfterRelease by remember { mutableStateOf(false) }
+    val currentShouldAnimatePosition = rememberUpdatedState(shouldAnimatePosition)
+    SideEffect {
+        if (shouldAnimatePosition) continueAnimatingAfterRelease = true
+    }
+    val usePreviewAnimation = shouldAnimatePosition || continueAnimatingAfterRelease
+    val displayedPosition by animateFloatAsState(
+        targetValue = targetPosition,
+        animationSpec = if (usePreviewAnimation) {
+            spring(
+                dampingRatio = Spring.DampingRatioNoBouncy,
+                stiffness = Spring.StiffnessMedium,
+                visibilityThreshold = 1f,
+            )
+        } else {
+            snap()
+        },
+        label = "seekPreviewPosition",
+        finishedListener = {
+            if (!currentShouldAnimatePosition.value) continueAnimatingAfterRelease = false
+        },
+    )
     CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
         Slider(
             modifier = modifier.fillMaxWidth(),
-            value = position.coerceIn(0f, duration.coerceAtLeast(0f)),
+            value = displayedPosition,
             valueRange = 0f..duration.coerceAtLeast(0f),
             onValueChange = onSeek,
             onValueChangeFinished = onSeekFinished,

--- a/feature/player/src/test/java/one/only/player/feature/player/state/SeekDragStabilizerTest.kt
+++ b/feature/player/src/test/java/one/only/player/feature/player/state/SeekDragStabilizerTest.kt
@@ -1,0 +1,38 @@
+package one.only.player.feature.player.state
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SeekDragStabilizerTest {
+    @Test
+    fun `ignores small direction reversals around the current preview`() {
+        val stabilizer = SeekDragStabilizer()
+
+        assertEquals(8f, stabilizer.add(dragAmount = 12f, hysteresisPx = 4f))
+        assertNull(stabilizer.add(dragAmount = -2f, hysteresisPx = 4f))
+        assertNull(stabilizer.add(dragAmount = 1f, hysteresisPx = 4f))
+        assertNull(stabilizer.add(dragAmount = -2f, hysteresisPx = 4f))
+        assertNull(stabilizer.add(dragAmount = 2f, hysteresisPx = 4f))
+    }
+
+    @Test
+    fun `follows deliberate movement in either direction`() {
+        val stabilizer = SeekDragStabilizer()
+
+        assertEquals(8f, stabilizer.add(dragAmount = 12f, hysteresisPx = 4f))
+        assertEquals(12f, stabilizer.add(dragAmount = 4f, hysteresisPx = 4f))
+        assertEquals(6f, stabilizer.add(dragAmount = -14f, hysteresisPx = 4f))
+    }
+
+    @Test
+    fun `reset removes displacement from the previous gesture`() {
+        val stabilizer = SeekDragStabilizer()
+
+        assertEquals(8f, stabilizer.add(dragAmount = 12f, hysteresisPx = 4f))
+        stabilizer.reset()
+
+        assertNull(stabilizer.add(dragAmount = 3f, hysteresisPx = 4f))
+        assertEquals(1f, stabilizer.add(dragAmount = 2f, hysteresisPx = 4f))
+    }
+}


### PR DESCRIPTION
## Summary
- stabilize screen seek previews with drag hysteresis and a non-bouncy UI transition
- keep the committed seek position stable while the player catches up after release
- deduplicate equivalent local media paths without collapsing distinct case-sensitive paths
- add seek drag stabilizer unit coverage

## Verification
- `gradlew.bat ktlintFormat ktlintCheck --no-daemon`
- `gradlew.bat test assembleDebug --warning-mode=fail --no-daemon`
- 13 tests passed, 0 failures
- verified both fixes on an Android 16 ARM64 device

Closes #186
Closes #187