### PR TITLE
fix: isolate crash handling and add startup timeout

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,7 +33,11 @@
             </intent-filter>
         </activity>
 
-        <activity android:name=".crash.CrashActivity" />
+        <activity
+            android:name=".crash.CrashActivity"
+            android:excludeFromRecents="true"
+            android:exported="false"
+            android:process=":crash" />
 
         <service
             android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
@@ -49,6 +53,17 @@
             android:authorities="${applicationId}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_provider_paths" />
+        </provider>
+
+        <provider
+            android:name=".crash.CrashLogFileProvider"
+            android:authorities="${applicationId}.crash.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true"
+            android:process=":crash">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_provider_paths" />

--- a/app/src/main/java/one/only/player/MainActivity.kt
+++ b/app/src/main/java/one/only/player/MainActivity.kt
@@ -54,6 +54,7 @@ import one.only.player.core.ui.components.AppDialog
 import one.only.player.core.ui.composables.rememberRuntimePermissionState
 import one.only.player.core.ui.extensions.LocalRootBottomBarPadding
 import one.only.player.core.ui.theme.OnlyPlayerTheme
+import one.only.player.crash.StartupWatchdog
 import one.only.player.feature.player.PlayerActivity
 import one.only.player.feature.videopicker.navigation.navigateToHistory
 import one.only.player.feature.videopicker.navigation.navigateToPlaylists
@@ -127,13 +128,17 @@ class MainActivity : AppCompatActivity() {
 
     @OptIn(ExperimentalComposeUiApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
+        StartupWatchdog.start(applicationContext)
         val persistedStartupPreferences = StartupPreferencesCache.consume(context = this)
         val bootstrapTheme = resolveBootstrapTheme(
             themeConfig = persistedStartupPreferences.themeConfig,
             isSystemDarkTheme = isSystemDarkTheme(resources.configuration),
         )
         setTheme(resolveBootstrapSplashThemeStyle(shouldUseDarkTheme = bootstrapTheme.shouldUseDarkTheme))
-        installSplashScreen().setOnExitAnimationListener { it.remove() }
+        installSplashScreen().setOnExitAnimationListener {
+            StartupWatchdog.markStartupComplete()
+            it.remove()
+        }
         super.onCreate(savedInstanceState)
         applyPrivacyProtection(
             shouldPreventScreenshots = viewModel.currentPreferences.shouldPreventScreenshots,

--- a/app/src/main/java/one/only/player/OnlyPlayerApplication.kt
+++ b/app/src/main/java/one/only/player/OnlyPlayerApplication.kt
@@ -1,6 +1,7 @@
 package one.only.player
 
 import android.app.Application
+import android.content.Context
 import coil3.ImageLoader
 import coil3.PlatformContext
 import coil3.SingletonImageLoader
@@ -10,7 +11,6 @@ import javax.inject.Inject
 import one.only.player.core.common.AppThemeModeManager
 import one.only.player.core.common.Logger
 import one.only.player.core.common.PredictiveBackSupport
-import one.only.player.crash.CrashActivity
 import one.only.player.crash.GlobalExceptionHandler
 
 @HiltAndroidApp
@@ -21,8 +21,24 @@ class OnlyPlayerApplication :
     @Inject
     lateinit var imageLoader: Lazy<ImageLoader>
 
+    override fun attachBaseContext(base: Context) {
+        super.attachBaseContext(base)
+        if (Application.getProcessName() == base.packageName) {
+            Thread.setDefaultUncaughtExceptionHandler(GlobalExceptionHandler(base))
+        }
+    }
+
     override fun onCreate() {
+        val processName = Application.getProcessName()
+        if (processName == "$packageName$CRASH_PROCESS_SUFFIX") {
+            // Keep the crash process independent from Hilt and main-process startup.
+            return
+        }
+
+        val isMainProcess = processName == packageName
         super.onCreate()
+        if (!isMainProcess) return
+
         AppForegroundTracker.register(this)
         val startupPreferences = StartupPreferencesCache.initialize(context = this)
         AppThemeModeManager.applyPlatformToCurrent(
@@ -34,8 +50,11 @@ class OnlyPlayerApplication :
             isEnabled = startupPreferences.shouldEnablePredictiveBack,
         )
         Logger.initialize(this)
-        Thread.setDefaultUncaughtExceptionHandler(GlobalExceptionHandler(applicationContext, CrashActivity::class.java))
     }
 
     override fun newImageLoader(context: PlatformContext): ImageLoader = imageLoader.get()
+
+    private companion object {
+        const val CRASH_PROCESS_SUFFIX = ":crash"
+    }
 }

--- a/app/src/main/java/one/only/player/crash/CrashActivity.kt
+++ b/app/src/main/java/one/only/player/crash/CrashActivity.kt
@@ -4,11 +4,10 @@ import android.content.ClipData
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
-import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -16,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -27,11 +25,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
-import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
-import dagger.hilt.android.AndroidEntryPoint
 import java.io.BufferedReader
 import java.io.File
 import java.io.InputStreamReader
@@ -41,19 +35,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import one.only.player.BuildConfig
 import one.only.player.MainActivity
-import one.only.player.MainActivityUiState
-import one.only.player.MainViewModel
-import one.only.player.core.common.extensions.applyPrivacyProtection
-import one.only.player.core.common.extensions.resolvePrivacyPreviewScrim
 import one.only.player.core.ui.R
 import one.only.player.core.ui.components.LogsSelectionContainer
 import one.only.player.core.ui.components.PageContentTopPadding
 import one.only.player.core.ui.designsystem.AppIcons
 import one.only.player.core.ui.extensions.withBottomFallback
 import one.only.player.core.ui.theme.OnlyPlayerTheme
-import one.only.player.navigation.NavigationBarColorEffect
-import one.only.player.shouldUseDarkTheme
-import one.only.player.shouldUseDynamicTheming
 import top.yukonga.miuix.kmp.basic.Icon
 import top.yukonga.miuix.kmp.basic.IconButton
 import top.yukonga.miuix.kmp.basic.Scaffold
@@ -61,80 +48,23 @@ import top.yukonga.miuix.kmp.basic.Text
 import top.yukonga.miuix.kmp.basic.TopAppBar
 import top.yukonga.miuix.kmp.theme.MiuixTheme
 
-@AndroidEntryPoint
 class CrashActivity : AppCompatActivity() {
-
-    private val viewModel: MainViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        applyPrivacyProtection(
-            shouldPreventScreenshots = viewModel.currentPreferences.shouldPreventScreenshots,
-            shouldHideInRecents = viewModel.currentPreferences.shouldHideInRecents,
-        )
-
-        var uiState: MainActivityUiState by mutableStateOf(MainActivityUiState.Loading)
-        val exceptionString = intent.getStringExtra("exception") ?: ""
+        enableEdgeToEdge()
+        val exceptionString = intent.getStringExtra(CrashScreenLauncher.EXTRA_EXCEPTION).orEmpty()
         var logcat by mutableStateOf("")
 
         lifecycleScope.launch {
             logcat = collectLogcat()
         }
 
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.uiState.collect { state ->
-                    uiState = state
-                }
-            }
-        }
-
-        installSplashScreen().setKeepOnScreenCondition {
-            when (uiState) {
-                MainActivityUiState.Loading -> true
-                is MainActivityUiState.Success -> false
-            }
-        }
-
         setContent {
-            val shouldUseDarkTheme = shouldUseDarkTheme(uiState = uiState)
-
-            val preferences = (uiState as? MainActivityUiState.Success)?.preferences
-            val shouldPreventScreenshots = preferences?.shouldPreventScreenshots == true
-            val shouldHideInRecents = preferences?.shouldHideInRecents == true
-
-            LaunchedEffect(shouldPreventScreenshots, shouldHideInRecents) {
-                if (preferences == null) return@LaunchedEffect
-                this@CrashActivity.applyPrivacyProtection(
-                    shouldPreventScreenshots = shouldPreventScreenshots,
-                    shouldHideInRecents = shouldHideInRecents,
-                )
-            }
-
-            LaunchedEffect(shouldHideInRecents, shouldUseDarkTheme) {
-                val systemBarScrim = this@CrashActivity.resolvePrivacyPreviewScrim(shouldHideInRecents)
-                enableEdgeToEdge(
-                    statusBarStyle = SystemBarStyle.auto(
-                        lightScrim = systemBarScrim,
-                        darkScrim = systemBarScrim,
-                        detectDarkMode = { shouldUseDarkTheme },
-                    ),
-                    navigationBarStyle = SystemBarStyle.auto(
-                        lightScrim = systemBarScrim,
-                        darkScrim = systemBarScrim,
-                        detectDarkMode = { shouldUseDarkTheme },
-                    ),
-                )
-            }
-
             OnlyPlayerTheme(
-                shouldUseDarkTheme = shouldUseDarkTheme,
-                shouldUseDynamicColor = shouldUseDynamicTheming(uiState = uiState),
+                shouldUseDarkTheme = isSystemInDarkTheme(),
+                shouldUseDynamicColor = false,
             ) {
-                NavigationBarColorEffect(
-                    activity = this@CrashActivity,
-                    color = MiuixTheme.colorScheme.surfaceContainer,
-                )
                 val clipboard = LocalClipboard.current
                 CrashScreen(
                     exceptionString = exceptionString,
@@ -157,8 +87,11 @@ class CrashActivity : AppCompatActivity() {
                         )
                     },
                     onRestartClick = {
+                        val restartIntent = Intent(this@CrashActivity, MainActivity::class.java).apply {
+                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                        }
+                        startActivity(restartIntent)
                         finish()
-                        startActivity(Intent(this@CrashActivity, MainActivity::class.java))
                     },
                 )
             }
@@ -182,7 +115,7 @@ class CrashActivity : AppCompatActivity() {
         file.writeText(text = logs)
         val uri = FileProvider.getUriForFile(
             this@CrashActivity,
-            "$packageName.fileprovider",
+            "$packageName.crash.fileprovider",
             file,
         )
         val intent = Intent(Intent.ACTION_SEND).apply {

--- a/app/src/main/java/one/only/player/crash/CrashLogFileProvider.kt
+++ b/app/src/main/java/one/only/player/crash/CrashLogFileProvider.kt
@@ -1,0 +1,5 @@
+package one.only.player.crash
+
+import androidx.core.content.FileProvider
+
+class CrashLogFileProvider : FileProvider()

--- a/app/src/main/java/one/only/player/crash/CrashScreenLauncher.kt
+++ b/app/src/main/java/one/only/player/crash/CrashScreenLauncher.kt
@@ -1,0 +1,17 @@
+package one.only.player.crash
+
+import android.content.Context
+import android.content.Intent
+
+internal object CrashScreenLauncher {
+
+    const val EXTRA_EXCEPTION = "exception"
+
+    fun launch(context: Context, exception: String) {
+        val intent = Intent(context, CrashActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            putExtra(EXTRA_EXCEPTION, exception)
+        }
+        context.startActivity(intent)
+    }
+}

--- a/app/src/main/java/one/only/player/crash/GlobalExceptionHandler.kt
+++ b/app/src/main/java/one/only/player/crash/GlobalExceptionHandler.kt
@@ -1,26 +1,37 @@
 package one.only.player.crash
 
 import android.content.Context
-import android.content.Intent
+import android.os.Process
+import android.util.Log
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.system.exitProcess
-import one.only.player.core.common.Logger
 
 class GlobalExceptionHandler(
     private val context: Context,
-    private val activity: Class<*>,
 ) : Thread.UncaughtExceptionHandler {
 
-    override fun uncaughtException(t: Thread, e: Throwable) {
-        Logger.error(TAG, "Uncaught exception on ${t.name}", e)
-        val intent = Intent(context, activity)
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
-        intent.putExtra("exception", e.stackTraceToString())
-        context.startActivity(intent)
-        exitProcess(0)
+    private val isHandlingException = AtomicBoolean(false)
+
+    override fun uncaughtException(thread: Thread, throwable: Throwable) {
+        if (!isHandlingException.compareAndSet(false, true)) terminateProcess()
+
+        Log.e(TAG, "Uncaught exception on ${thread.name}", throwable)
+        try {
+            CrashScreenLauncher.launch(context, throwable.stackTraceToString())
+        } catch (launchException: RuntimeException) {
+            Log.e(TAG, "Unable to launch crash screen", launchException)
+        } finally {
+            terminateProcess()
+        }
+    }
+
+    private fun terminateProcess(): Nothing {
+        Process.killProcess(Process.myPid())
+        exitProcess(EXIT_CODE_CRASH)
     }
 
     private companion object {
         const val TAG = "GlobalExceptionHandler"
+        const val EXIT_CODE_CRASH = 1
     }
 }

--- a/app/src/main/java/one/only/player/crash/StartupWatchdog.kt
+++ b/app/src/main/java/one/only/player/crash/StartupWatchdog.kt
@@ -1,0 +1,62 @@
+package one.only.player.crash
+
+import android.content.Context
+import android.os.Process
+import android.util.Log
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.system.exitProcess
+
+internal object StartupWatchdog {
+
+    private val hasStarted = AtomicBoolean(false)
+    private val hasCompleted = AtomicBoolean(false)
+    private val watchdogThread = AtomicReference<Thread?>()
+
+    fun start(context: Context) {
+        if (!hasStarted.compareAndSet(false, true)) return
+
+        val thread = Thread(
+            {
+                try {
+                    Thread.sleep(STARTUP_TIMEOUT_MILLIS)
+                } catch (_: InterruptedException) {
+                    return@Thread
+                }
+
+                if (!hasCompleted.compareAndSet(false, true)) return@Thread
+
+                Log.e(TAG, STARTUP_TIMEOUT_MESSAGE)
+                try {
+                    CrashScreenLauncher.launch(context, STARTUP_TIMEOUT_MESSAGE)
+                } catch (launchException: RuntimeException) {
+                    Log.e(TAG, "Unable to launch crash screen", launchException)
+                } finally {
+                    terminateProcess()
+                }
+            },
+            THREAD_NAME,
+        ).apply {
+            isDaemon = true
+        }
+        watchdogThread.set(thread)
+        thread.start()
+    }
+
+    fun markStartupComplete() {
+        if (!hasCompleted.compareAndSet(false, true)) return
+        watchdogThread.getAndSet(null)?.interrupt()
+    }
+
+    private fun terminateProcess(): Nothing {
+        Process.killProcess(Process.myPid())
+        exitProcess(EXIT_CODE_TIMEOUT)
+    }
+
+    private const val STARTUP_TIMEOUT_MILLIS = 10_000L
+    private const val STARTUP_TIMEOUT_MESSAGE =
+        "StartupTimeoutException: startup splash screen did not exit within 10 seconds."
+    private const val THREAD_NAME = "startup-watchdog"
+    private const val TAG = "StartupWatchdog"
+    private const val EXIT_CODE_TIMEOUT = 10
+}


### PR DESCRIPTION
## Summary

- run `CrashActivity` and its log `FileProvider` in a dedicated `:crash` process
- install the uncaught exception handler before application initialization
- keep the crash process independent from Hilt, app preferences, and `MainViewModel`
- add a 10-second startup watchdog that is cancelled when the splash screen exits
- launch the crash screen and terminate the stuck main process when startup times out
- avoid arming the watchdog when the main process is started only for a provider
- use a crash-process-specific `FileProvider` when sharing crash logs

## Problem

The crash screen previously ran in the main application process and depended on the same Hilt graph, preferences, ViewModel, and splash-screen state as the normal startup flow.

As a result, crashes or hangs during startup could prevent the crash screen itself from being displayed.

## Implementation

The uncaught exception handler is installed from `Application.attachBaseContext()` so it can capture failures occurring during early application, Hilt, or provider initialization.

`CrashActivity` now runs in the `:crash` process and avoids main-process initialization dependencies. The crash process intentionally skips generated Hilt application initialization.

A dedicated daemon thread starts at the beginning of `MainActivity.onCreate()`. If the splash screen has not exited within 10 seconds, it launches the independent crash screen and terminates the stuck main process. Normal startup is not blocked: the watchdog sleeps off the main thread and is interrupted when the splash screen exits.

## Validation

Performed on a temporary VPS with JDK 25 and Android SDK 37:

- `./gradlew ktlintFormat`
- `./gradlew ktlintCheck test assembleDebug --warning-mode=fail`
- `python3 scripts/build.py build-apk --abi arm64-v8a --build-type debug`
- verified the merged manifest assigns both `CrashActivity` and `CrashLogFileProvider` to `:crash`
- verified all existing 10 unit tests pass with no failures or errors
- successfully generated arm64-v8a and x86_64 debug APKs

No test files or additional test scripts were introduced.

## Runtime validation note

Device-level fault injection was attempted on the VPS. The host does not expose KVM, and the Android emulator crashed inside software emulation before PackageManager became available. This was an emulator/environment failure rather than an application failure.