### PR TITLE
fix(player): prevent seek progress flicker after scrubbing

### DIFF
--- a/feature/player/src/main/java/one/only/player/feature/player/MediaPlayerScreen.kt
+++ b/feature/player/src/main/java/one/only/player/feature/player/MediaPlayerScreen.kt
@@ -243,6 +243,7 @@ internal fun MediaPlayerScreen(
         player = player,
         sensitivity = playerPreferences.seekSensitivity,
         isSeekGestureEnabled = playerPreferences.shouldUseSeekControls,
+        onSeekCommitted = mediaPresentationState::onSeekCommitted,
     )
     val pictureInPictureState = rememberPictureInPictureState(
         player = player,

--- a/feature/player/src/main/java/one/only/player/feature/player/state/MediaPresentationState.kt
+++ b/feature/player/src/main/java/one/only/player/feature/player/state/MediaPresentationState.kt
@@ -164,6 +164,10 @@ class MediaPresentationState(
         }
     }
 
+    fun onSeekCommitted(positionMs: Long) {
+        position = positionMs.coerceAtLeast(0L)
+    }
+
     private fun updatePosition() {
         position = player.currentPosition.coerceAtLeast(0L)
     }

--- a/feature/player/src/main/java/one/only/player/feature/player/state/SeekGestureState.kt
+++ b/feature/player/src/main/java/one/only/player/feature/player/state/SeekGestureState.kt
@@ -25,12 +25,14 @@ fun rememberSeekGestureState(
     player: Player,
     sensitivity: Float = 0.5f,
     isSeekGestureEnabled: Boolean,
+    onSeekCommitted: (Long) -> Unit,
 ): SeekGestureState {
     val seekGestureState = remember {
         SeekGestureState(
             player = player,
             sensitivity = sensitivity,
             isSeekGestureEnabled = isSeekGestureEnabled,
+            onSeekCommitted = onSeekCommitted,
         )
     }
     return seekGestureState
@@ -41,6 +43,7 @@ class SeekGestureState(
     private val player: Player,
     private val isSeekGestureEnabled: Boolean = true,
     private val sensitivity: Float = 0.5f,
+    private val onSeekCommitted: (Long) -> Unit = {},
 ) {
     var isSeeking: Boolean by mutableStateOf(false)
         private set
@@ -126,6 +129,7 @@ class SeekGestureState(
         if (currentPosition == null || currentPosition != pendingSeekPosition) {
             player.seekToRequestedPosition(pendingSeekPosition)
         }
+        onSeekCommitted(pendingSeekPosition)
     }
 
     private fun reset() {


### PR DESCRIPTION
## Summary

- keep the progress indicator at the committed seek target when a swipe or slider interaction ends
- synchronize the presentation position before clearing the pending seek state
- continue letting Media3 position events take over as the playback source of truth

## Root cause

The seek target was committed and `pendingSeekPosition` was cleared immediately. Before the next Media3 position-discontinuity event updated `MediaPresentationState`, the progress indicator briefly rendered the previous position, producing a target → old → target flash.

## Validation

- `./gradlew ktlintFormat ktlintCheck`
- `./gradlew :feature:player:testDebugUnitTest --warning-mode=fail`
- `python3 scripts/build.py build-apk --abi arm64-v8a --build-type debug`
- built `Only-Player-debug-arm64-v8a-1.0.177.apk` successfully on the temporary VPS with JDK 25 and Android SDK 37

## Notes

- no test files or scripts were added or modified
- a final touch-device check is recommended for the release gesture path
